### PR TITLE
Fix test failures and configure for Travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: cpp
+addons:
+  apt:
+    packages:
+      - cmake
+      - libboost-dev
+      - libboost-serialization-dev
+script: scons --keep-going checking=slow tests

--- a/AddOns/Domains/Source/wali/domains/lh/LH.cpp
+++ b/AddOns/Domains/Source/wali/domains/lh/LH.cpp
@@ -941,6 +941,7 @@ void LH::printPly(char* v, int size, int ply)
         switch(v[offset]) {
           case -1:
             ss << "*";
+	    // intentional fall-through
           case 1:
             ss << (char)('a'+l);
             break;

--- a/AddOns/Domains/Source/wali/domains/lh/PhaseLH.cpp
+++ b/AddOns/Domains/Source/wali/domains/lh/PhaseLH.cpp
@@ -1115,6 +1115,7 @@ void PhaseLH::print_r_compat(char* v, int size)
           switch(v[offset]) {
             case -1:
               ss << "*";
+	      // intentional fall-through
             case 1:
               ss << (char)('a'+l);
               break;
@@ -1479,6 +1480,7 @@ void PhaseLH::print_sum(char* v, int size)
           switch(v[offset]) {
             case -1:
               ss << "*";
+	      // intentional fall-through
             case 1:
               ss << (char)('a'+l);
               break;

--- a/Source/wali/domains/TraceSplitSemElem.hpp
+++ b/Source/wali/domains/TraceSplitSemElem.hpp
@@ -368,7 +368,7 @@ namespace wali
         }
         else {
           os << "(some guard) -> ";
-          os << begin()->second->print_typename(os);
+          begin()->second->print_typename(os);
         }
         return os << ">";
       }

--- a/Source/wali/domains/TraceSplitSemElem.hpp
+++ b/Source/wali/domains/TraceSplitSemElem.hpp
@@ -87,7 +87,7 @@ namespace wali
 
       virtual bool isFalse() const {
         assert (!_special || *_special == SpecialFalse);
-        return _special;
+        return static_cast<bool>(_special);
       }
 
       virtual std::ostream& print(std::ostream & os) const {

--- a/Source/wali/util/DisjointSets.hpp
+++ b/Source/wali/util/DisjointSets.hpp
@@ -1,6 +1,7 @@
 #ifndef WALI_UTIL_DISJOINT_SETS_HPP
 #define WALI_UTIL_DISJOINT_SETS_HPP
 
+#include "wali/Common.hpp"
 #include "wali/util/details/Partition.hpp"
 #include "wali/util/map_at.hpp"
 


### PR DESCRIPTION
The first several commits in this request fix various compilation failures that arose when running `scons tests` under Fedora 27, using the standard gcc 7.3.1 that is part of that distribution.

The last commit in this request, e308acf0a691089690275abdfec6adce8b97baaf, adds a Travis CI configuration for automated regression testing. My hope is that this will discourage anyone from committing changes that break WALi in the future. Note, however, that some [member of the WaliDev GitHub organization](https://github.com/orgs/WaliDev/people) will need to enable Travis CI testing. After merging this request, **follow the first two steps** of the “[To get started with Travis CI](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI)” instructions to turn this on.