### PR TITLE
Fixed const cast issue.

### DIFF
--- a/Source/wali/graph/IntraGraph.cpp
+++ b/Source/wali/graph/IntraGraph.cpp
@@ -1575,7 +1575,7 @@ namespace wali {
       std::stringstream ss;
       for(int i = 0; i < nnodes; ++i){
         if(i != 0){
-        const long regexpaddr = (const long) nodes[i].regexp.get_ptr();
+        const long regexpaddr = (long) nodes[i].regexp.get_ptr();
         ss << "node" << i << " [label=\"(" << key2str(nodes[i].trans.src) 
           << ", " << key2str(nodes[i].trans.stack) << ", " 
           << key2str(nodes[i].trans.tgt) << ")\\n" << regexpaddr


### PR DESCRIPTION
Very small change that fixed a compilation aborting warning for me under g++ 8.1.1. Thought I'd let you know. 